### PR TITLE
Add AWS Free Tier to AWS Learning Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 ## AWS Learning Resources
 - [AWS Skill Builder](https://skillbuilder.aws/)
+- [AWS Free Tier](https://aws.amazon.com/free/)
 
 ## Contributors
 


### PR DESCRIPTION
Add AWS Free Tier to encourage practical learning. 

### Resource Name and Link

**Resource Name**: AWS Free Tier
**Resource Link**: `https://aws.amazon.com/free/` 

---

### Resource Category

**Category**: AWS Learning Resources

---

- [ ] I have read and followed the [Contribution Guidelines].  
- [ ] The resource is relevant and useful for development purposes.  
- [ ] I have added the resource to the appropriate section in `README.md`. 